### PR TITLE
fix: #WB2-1304, show in trash a trashed shared resource from a folder by shared user

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/ExplorerMessageForIngest.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/ExplorerMessageForIngest.java
@@ -89,6 +89,10 @@ public class ExplorerMessageForIngest extends ExplorerMessage {
         return this.getMessage().getBoolean("trashed", false);
     }
 
+    public boolean isTrashedBy(String userId) {
+        return this.getTrashedBy().contains(userId);
+    }
+
     public boolean isFolderMessage(){
         return ExplorerConfig.FOLDER_TYPE.equals(getResourceType())
                 && ExplorerConfig.FOLDER_TYPE.equals(getEntityType());

--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElasticOperation.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElasticOperation.java
@@ -34,7 +34,8 @@ abstract class MessageIngesterElasticOperation {
             case Delete:
                 return Arrays.asList(new MessageIngesterElasticOperationDelete(message));
             case Upsert:
-                if(ExplorerConfig.getInstance().isSkipIndexOfTrashedFolders() && message.isTrashed()){
+                if(ExplorerConfig.getInstance().isSkipIndexOfTrashedFolders()
+                        && (message.isTrashed() || message.isTrashedBy(message.getUpdaterId()))){
                     //specific indexation for trashed message
                     if(message.isFolderMessage()){
                         //folder are not indexed


### PR DESCRIPTION
# Description

When a user trashes a resource that is in a folder and shared, the resource appears now in Trash

https://edifice-community.atlassian.net/browse/WB2-1304

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
