### PR TITLE
fix: #WB2-1457, duplicate action only available if one resource is selected and not available for folder

### DIFF
--- a/frontend/src/features/ActionBar/useActionBar.tsx
+++ b/frontend/src/features/ActionBar/useActionBar.tsx
@@ -132,6 +132,8 @@ export default function useActionBar() {
         return onlyOneSelected;
       case ACTION.MANAGE:
         return onlyOneItemSelected;
+      case ACTION.COPY:
+        return onlyOneItemSelected && noFolderSelected;
       case ACTION.PUBLISH:
         return onlyOneItemSelected && noFolderSelected;
       case ACTION.UPD_PROPS:


### PR DESCRIPTION
# Description

Duplicate action only available if one resource is selected and not available for folder.

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
