### PR TITLE
[EDIFICE] #Wb2 1373, Amélioration des performances d'ingestion

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/Explorer.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/Explorer.java
@@ -73,10 +73,11 @@ public class Explorer extends BaseServer {
         super.start();
         final boolean runjobInWroker = config.getBoolean("worker-job", true);
         final boolean poolMode = config.getBoolean("postgres-pool-mode", true);
+        final boolean enablePgBus = config.getBoolean("postgres-enable-bus", true);
         final List<Future> futures = new ArrayList<>();
         //create postgres client
         log.info("Init postgres bus consumer...");
-        if (runjobInWroker) {
+        if (runjobInWroker && enablePgBus) {
             IPostgresClient.initPostgresConsumer(vertx, config, poolMode);
         }
         final IPostgresClient postgresClient = IPostgresClient.create(vertx, config, false, poolMode);

--- a/backend/src/main/java/com/opendigitaleducation/explorer/folders/FolderExplorerDbSql.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/folders/FolderExplorerDbSql.java
@@ -365,7 +365,8 @@ public class FolderExplorerDbSql {
         final StringBuilder query = new StringBuilder();
         query.append("WITH RECURSIVE ancestors(id,name, parent_id, application) AS ( ");
         query.append(String.format("   SELECT f1.id, f1.name, f1.parent_id, f1.application FROM explorer.folders f1 WHERE f1.id IN (%s) ", inPlaceholder));
-        query.append("   UNION ALL ");
+        // remove duplicate and avoid infinite loop
+        query.append("   UNION ");
         query.append("   SELECT f2.id, f2.name, f2.parent_id, f2.application FROM explorer.folders f2, ancestors  WHERE f2.id = ancestors.parent_id ");
         query.append(") ");
         query.append("SELECT * FROM ancestors;");
@@ -403,7 +404,8 @@ public class FolderExplorerDbSql {
         final StringBuilder query = new StringBuilder();
         query.append("WITH RECURSIVE ancestors(id,name, parent_id, application) AS ( ");
         query.append(String.format("   SELECT f1.id, f1.name, f1.parent_id, f1.application FROM explorer.folders f1 WHERE f1.id IN (%s) ", inPlaceholder));
-        query.append("   UNION ALL ");
+        // remove duplicate and avoid infinite loop
+        query.append("   UNION ");
         query.append("   SELECT f2.id, f2.name, f2.parent_id, f2.application FROM explorer.folders f2, ancestors  WHERE f2.parent_id = ancestors.id ");
         query.append(") ");
         query.append("SELECT * FROM ancestors;");

--- a/backend/src/main/resources/sql/007-indexes.sql
+++ b/backend/src/main/resources/sql/007-indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_folders_parent_id ON explorer.folders USING btree (parent_id);
+CREATE INDEX idx_resources_entid ON explorer.resources USING btree (ent_id);


### PR DESCRIPTION
# Description

Ce commit vient ajouter des améliorations de performance permettant de monter à 400 messages par secondes en moyenne:
- ajout d'une conf pour utiliser ou non le bus postgres
- ajout d'une conf pour utiliser ou non le pool pg
- suppression de la directive UNION ALL dans les requêtes récursives pour éviter des doublons et des infinites loop

Testé avec :
- le job dans l'event pool (pas de worker)
- le pool pg actif
=> 400messages par secondes 

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings
