### PR TITLE
feat: #WB2-1778, track Library access event

### DIFF
--- a/frontend/src/features/SideBar/Library/Library.tsx
+++ b/frontend/src/features/SideBar/Library/Library.tsx
@@ -1,26 +1,11 @@
+import { useLibrary } from "./useLibrary";
 import { ArrowRight } from "@edifice-ui/icons";
-import {
-  usePaths,
-  useOdeTheme,
-  useLibraryUrl,
-  Image,
-  useSession,
-} from "@edifice-ui/react";
+import { Image } from "@edifice-ui/react";
 import { useTranslation } from "react-i18next";
 
 const Library = () => {
+  const { libraryUrl, imageFullURL, handleClick } = useLibrary();
   const { t } = useTranslation();
-  const sessionQuery = useSession();
-  const { theme } = useOdeTheme();
-  const libraryUrl = useLibraryUrl();
-  const [imagePath] = usePaths();
-
-  // #WB2-1689: add end of year Library gif only for FR users
-  const imageFilename =
-    sessionQuery?.data?.currentLanguage === "fr"
-      ? "image-library-year-end.gif"
-      : "image-library.svg";
-  const imageFullURL = `${imagePath}/${theme?.bootstrapVersion}/${imageFilename}`;
 
   return (
     libraryUrl && (
@@ -34,15 +19,15 @@ const Library = () => {
           alt={t("explorer.libray.img.alt")}
         />
         <p className="m-8">{t("explorer.libray.title")}</p>
-        <a
-          href={libraryUrl}
-          target="_blank"
+        <button
+          type="button"
+          onClick={handleClick}
           rel="noreferrer"
-          className="d-inline-flex align-items-center gap-4 btn btn-ghost-primary py-0 p-0 pe-8"
+          className="btn btn-ghost-primary d-inline-flex align-items-center gap-4 p-8"
         >
           <span>{t("explorer.libray.btn")}</span>
           <ArrowRight />
-        </a>
+        </button>
       </div>
     )
   );

--- a/frontend/src/features/SideBar/Library/useLibrary.tsx
+++ b/frontend/src/features/SideBar/Library/useLibrary.tsx
@@ -1,0 +1,34 @@
+import {
+  useLibraryUrl,
+  useOdeClient,
+  useOdeTheme,
+  usePaths,
+} from "@edifice-ui/react";
+import { odeServices } from "edifice-ts-client";
+
+export const useLibrary = () => {
+  const { currentLanguage } = useOdeClient();
+  const { theme } = useOdeTheme();
+  const [imagePath] = usePaths();
+  const libraryUrl = useLibraryUrl();
+
+  // #WB2-1689: add end of year Library gif only for FR users
+  const imageFilename =
+    currentLanguage === "fr"
+      ? "image-library-year-end.gif"
+      : "image-library.svg";
+  const imageFullURL = `${imagePath}/${theme?.bootstrapVersion}/${imageFilename}`;
+
+  /**
+   * Open Library in new tab and Track access (event: ACCESS_LIBRARY_FROM_EXPLORER).
+   * Important: Event "ACCESS_LIBRARY_FROM_EXPLORER" needs to be added in infra module configuration "eventConfig.event-whitelist" in Vertx configuration file.
+   */
+  const handleClick = () => {
+    if (libraryUrl) {
+      window.open(libraryUrl, "_blank");
+      odeServices.data().trackAccessLibraryFromExplorer();
+    }
+  };
+
+  return { libraryUrl, imageFullURL, handleClick };
+};


### PR DESCRIPTION
# Description

Track Library access event from explorer to measure the importance of the Library promotion button in Explorer page.

Use of infra events API: `POST /infra/event/web/store` with an `event-type` equals to `ACCESS_LIBRARY_FROM_EXPLORER`.

Event `ACCESS_LIBRARY_FROM_EXPLORER` needs to be added in infra module configuration "eventConfig.event-whitelist" in Vertx configuration file.

@jcbe-ode est-ce que tu peux jeter un oeil sur l'ajout de cet event et me dire si c'est ok stp ? Le fait de devoir l'ajouter à la config serveur je me demande si c'est accepté pour ce genre d'événement ^^' Merci ! :)

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
