### PR TITLE
fix: #wb2-1879, suppression du liens avec le dossier lors d'un mute

### DIFF
--- a/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElasticOperation.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/ingest/MessageIngesterElasticOperation.java
@@ -41,9 +41,6 @@ abstract class MessageIngesterElasticOperation {
                         //folder are not indexed
                         return Arrays.asList(new MessageIngesterElasticOperationDelete(message));
                     }else{
-                        //break folder/resource link
-                        message.getMessage().put("folderIds", new JsonArray());
-                        message.getMessage().put("usersForFolderIds", new JsonArray());
                         return Arrays.asList(new MessageIngesterElasticOperationUpsert(message));
                     }
                 }else{

--- a/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceServiceElastic.java
+++ b/backend/src/main/java/com/opendigitaleducation/explorer/services/impl/ResourceServiceElastic.java
@@ -166,12 +166,13 @@ public class ResourceServiceElastic implements ResourceService {
                 return Future.failedFuture("resource.trash.id.invalid");
             }
             final Set<Integer> idsToTrashForAll = new HashSet<>();
-            final Set<IdAndVersion> idsToTrashForUserOnly = new HashSet<>();
+            final Set<ResourceExplorerDbSql.ResourceIdAndVersion> idsToTrashForUserOnly = new HashSet<>();
             for (JsonObject row : fetch.rows) {
+                final Integer openSearchId = Integer.parseInt(row.getString("_id"));
                 if (isManager(row, user)) {
-                    idsToTrashForAll.add(Integer.parseInt(row.getString("_id")));
+                    idsToTrashForAll.add(openSearchId);
                 } else {
-                    idsToTrashForUserOnly.add(new IdAndVersion(row.getString("assetId"), row.getLong("version")));
+                    idsToTrashForUserOnly.add(new ResourceExplorerDbSql.ResourceIdAndVersion(openSearchId, row.getString("assetId"), row.getLong("version")));
                 }
             }
             //TODO remove previous parent if it is not trashed


### PR DESCRIPTION
# Description

Lorsque quelqu'un mettait une ressource en mute, il cassait le lien de tout les dossiers de tout les utilisateurs. ce lien était automatiquement restauré lorsqu'un autre user mettait à jour la ressource
ce fix vient casser le lien uniquement entre la ressource et le dossier de celui qui a mis en trash/mute

>

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes generate no new warnings
